### PR TITLE
Prevent execute command error when load-file-name contains whitespace

### DIFF
--- a/visual-regexp-steroids.el
+++ b/visual-regexp-steroids.el
@@ -43,7 +43,7 @@
 ;;; variables
 
 (defvar vr--command-python-default
-  (format "python %s" (expand-file-name "regexp.py" (file-name-directory load-file-name))))
+  (format "python \"%s\"" (expand-file-name "regexp.py" (file-name-directory load-file-name))))
 
 (defcustom vr/command-python vr--command-python-default
   "External command used for the Python engine."
@@ -293,7 +293,9 @@ and the message line."
            (format "%s matches --regexp %s %s %s"
                    (vr--get-command)
                    (shell-quote-argument regexp-string)
-                   (when feedback-limit (format "--feedback-limit %s" feedback-limit))
+                   (if feedback-limit 
+                       (format "--feedback-limit %s" feedback-limit)
+                       "")
                    (if forward "" "--backwards"))
            (lambda (output)
              (vr--parse-matches


### PR DESCRIPTION
When load-file-name, will lead to this error:

``` =>
[(error External command failed with exit code 2)]
```

Escape string of the path could avoid this error.
