### PR TITLE
Fix path with space in command for Aquamacs

### DIFF
--- a/visual-regexp-steroids.el
+++ b/visual-regexp-steroids.el
@@ -46,7 +46,9 @@
 ;;; variables
 
 (defvar vr--command-python-default
-  (format "python %s" (expand-file-name "regexp.py" (file-name-directory load-file-name))))
+  (format "python %s"
+          (shell-quote-argument (expand-file-name "regexp.py"
+                                                  (file-name-directory load-file-name)))))
 
 (defcustom vr/command-python vr--command-python-default
   "External command used for the Python engine."

--- a/visual-regexp-steroids.el
+++ b/visual-regexp-steroids.el
@@ -46,7 +46,7 @@
 ;;; variables
 
 (defvar vr--command-python-default
-  (format "python %s"
+  (format "python \"%s\""
           (shell-quote-argument (expand-file-name "regexp.py"
                                                   (file-name-directory load-file-name)))))
 

--- a/visual-regexp-steroids.el
+++ b/visual-regexp-steroids.el
@@ -297,7 +297,9 @@ and the message line."
                 (format "%s matches --regexp %s %s %s"
                         (vr--get-command)
                         (shell-quote-argument regexp-string)
-                        (when feedback-limit (format "--feedback-limit %s" feedback-limit))
+                        (if feedback-limit
+                            (format "--feedback-limit %s" feedback-limit)
+                          "")
                         (if forward "" "--backwards"))
                 (lambda (output)
                   (vr--parse-matches

--- a/visual-regexp-steroids.el
+++ b/visual-regexp-steroids.el
@@ -46,7 +46,7 @@
 ;;; variables
 
 (defvar vr--command-python-default
-  (format "python \"%s\""
+  (format "python %s"
           (shell-quote-argument (expand-file-name "regexp.py"
                                                   (file-name-directory load-file-name)))))
 


### PR DESCRIPTION
use `shell-quote-argument` instead.